### PR TITLE
Move pull-quote scraping + capsule pre-gen from local Mac to CI

### DIFF
--- a/.github/workflows/daily-check.yml
+++ b/.github/workflows/daily-check.yml
@@ -74,9 +74,38 @@ jobs:
           git config user.name "NRW Bot"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      # Hard guard: the hand-curated capsule bank must never be CI-managed.
+      # If it ever becomes git-tracked, CI could overwrite the user's curated
+      # capsules — fail loudly instead.
+      - name: Guard hand-curated capsule bank
+        run: |
+          if git ls-files --error-unmatch cache/approved_capsules.json >/dev/null 2>&1; then
+            echo "::error::cache/approved_capsules.json is tracked — CI must never manage the curated capsule bank"
+            exit 1
+          fi
+          echo "✅ approved_capsules.json is not tracked (correct)"
 
       - name: Run daily pipeline
         run: python3 daily_orchestrator.py | tee .local_run.log
+
+      # --- Curation pre-compute (moved off the local Mac) -------------------
+      # These two steps do the slow Gemini/Playwright work that used to run on
+      # the laptop overnight. They are NON-CRITICAL: a scraping hiccup must
+      # never block the data.json publish, so both use continue-on-error.
+      # Results are handed back to the Mac via the "curation-caches" artifact
+      # (see the upload step below) — they are NOT committed to git.
+      - name: Pre-scrape pull quotes for new arrivals
+        if: always()
+        continue-on-error: true
+        run: |
+          python3 scripts/batch_pull_quotes.py || echo "Pull-quote pre-scrape failed, continuing..."
+
+      - name: Pre-generate capsules for new arrivals
+        if: always()
+        continue-on-error: true
+        run: |
+          python3 scripts/write_capsule.py --batch --days 7 --variants 3 --skip-verify \
+            || echo "Capsule pre-gen failed, continuing..."
 
       - name: Restore YouTube credentials
         env:
@@ -268,6 +297,20 @@ jobs:
             movie_tracking.json
             data.json
           retention-days: 7
+
+      # Hand the CI-generated curation caches back to the local Mac.
+      # Stable artifact name so local_daily.sh can fetch the latest run's copy.
+      # Never includes approved_capsules.json (the curated bank stays local).
+      - name: Upload curation caches (pull quotes + capsules)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: curation-caches
+          path: |
+            cache/pull_quotes_combined.json
+            cache/capsule_cache.json
+          retention-days: 7
+          if-no-files-found: warn
 
       - name: Commit changes
         if: always() && steps.changes.outputs.changes == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,12 @@ output/
 *_cache.json
 cache/*.json
 !cache/wikipedia_cache.json
+# Curation caches (pull_quotes_combined.json, capsule_cache.json) stay IGNORED:
+# CI generates them and ships them via the "curation-caches" artifact, which
+# local_daily.sh merges in. They are deliberately NOT tracked.
+# cache/approved_capsules.json is the hand-curated bank — it must ALSO stay
+# ignored so CI can never overwrite it (enforced by the "Guard hand-curated
+# capsule bank" step in .github/workflows/daily-check.yml).
 cache/screenshots/*.png
 cache/screenshots/*.html
 # Legacy cache file locations (for backwards compatibility)

--- a/scripts/local_daily.sh
+++ b/scripts/local_daily.sh
@@ -87,24 +87,43 @@ fi
 CI_DATE=$(/usr/bin/python3 -c "import json; print(json.load(open('metrics/run_diagnostics.json'))['timestamp'][:10])" 2>/dev/null)
 TODAY=$(date +%Y-%m-%d)
 if [ "$CI_DATE" = "$TODAY" ]; then
-    # Step 4: Scrape pull quotes for new movies (ready for morning curation)
-    # alarm(3600) hard-kills after 1 hour — same backstop as the trailer step.
-    # Without it, one hung scrape froze this script (and all runs behind it)
-    # for 3 days in June 2026.
-    echo "Scraping pull quotes for new arrivals..." >> "$LOG"
-    /usr/bin/perl -e 'alarm(3600); exec @ARGV' -- \
-        /usr/bin/python3 scripts/batch_pull_quotes.py >> "$LOG" 2>&1 \
-        || echo "  WARNING: pull quotes exited non-zero (timeout or error)" >> "$LOG"
-    echo "  Pull quotes done" >> "$LOG"
+    # Steps 4+5: Curation caches (pull quotes + capsule drafts).
+    # These now run in CI (daily-check.yml) — off this battery-dependent Mac —
+    # and are shipped back as the "curation-caches" artifact. We just download
+    # and merge them in (merge is add-new-only, so it never clobbers the user's
+    # `selected` picks or curated capsules). If the artifact can't be fetched,
+    # we FALL BACK to generating locally so curation is never left empty.
+    echo "Fetching curation caches from CI artifact..." >> "$LOG"
+    ARTIFACT_OK=false
+    TMP_ART="$PROJECT_DIR/cache/_ci_artifact"
+    rm -rf "$TMP_ART" && mkdir -p "$TMP_ART"
+    RUN_ID=$(gh run list --repo hadrianbelove-stack/nrw-production \
+        --workflow daily-check.yml --status success --limit 1 \
+        --json databaseId -q '.[0].databaseId' 2>>"$LOG")
+    if [ -n "$RUN_ID" ] && gh run download "$RUN_ID" \
+            --repo hadrianbelove-stack/nrw-production \
+            --name curation-caches --dir "$TMP_ART" >> "$LOG" 2>&1; then
+        if /usr/bin/python3 scripts/merge_curation_caches.py "$TMP_ART" >> "$LOG" 2>&1; then
+            ARTIFACT_OK=true
+            echo "  Curation caches merged from CI run $RUN_ID" >> "$LOG"
+        fi
+    fi
+    rm -rf "$TMP_ART"
 
-    # Step 5: Pre-generate capsules (3 variants) for new arrivals so curation
-    # reads them from cache/capsule_cache.json instead of waiting on live LLM calls.
-    # Skips already-cached movies; alarm(3600) hard-kills a hung run.
-    echo "Pre-generating capsules for new arrivals..." >> "$LOG"
-    /usr/bin/perl -e 'alarm(3600); exec @ARGV' -- \
-        /usr/bin/python3 scripts/write_capsule.py --batch --days 7 --variants 3 --skip-verify >> "$LOG" 2>&1 \
-        || echo "  WARNING: capsule batch exited non-zero (timeout or error)" >> "$LOG"
-    echo "  Capsules done" >> "$LOG"
+    if [ "$ARTIFACT_OK" = false ]; then
+        # Fallback: CI artifact unavailable — generate locally (the old path).
+        # alarm(3600) hard-kills a hung run so it can't freeze later cycles.
+        echo "  Artifact unavailable — falling back to local generation" >> "$LOG"
+        echo "Scraping pull quotes for new arrivals..." >> "$LOG"
+        /usr/bin/perl -e 'alarm(3600); exec @ARGV' -- \
+            /usr/bin/python3 scripts/batch_pull_quotes.py >> "$LOG" 2>&1 \
+            || echo "  WARNING: pull quotes exited non-zero (timeout or error)" >> "$LOG"
+        echo "Pre-generating capsules for new arrivals..." >> "$LOG"
+        /usr/bin/perl -e 'alarm(3600); exec @ARGV' -- \
+            /usr/bin/python3 scripts/write_capsule.py --batch --days 7 --variants 3 --skip-verify >> "$LOG" 2>&1 \
+            || echo "  WARNING: capsule batch exited non-zero (timeout or error)" >> "$LOG"
+    fi
+    echo "  Curation caches ready" >> "$LOG"
 
     touch "$SENTINEL"
     echo "  CI data is current ($CI_DATE) — sentinel created, done for today" >> "$LOG"

--- a/scripts/merge_curation_caches.py
+++ b/scripts/merge_curation_caches.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Merge CI-generated curation caches into the local caches.
+
+CI (daily-check.yml) does the slow pull-quote scraping and capsule
+pre-generation, then ships the results as the "curation-caches" artifact.
+local_daily.sh downloads that artifact and calls this script to fold the
+results into the Mac's working caches.
+
+KEY RULE — add-new-only. We NEVER overwrite an entry that already exists
+locally. The local caches carry curation STATE the CI copy doesn't have:
+  - pull_quotes_combined.json: the user's `selected: true` picks and trims
+  - capsule_cache.json: any locally tweaked drafts
+CI only fills GAPS (films it scraped/wrote that the Mac hasn't seen yet),
+so a re-run can never reset a pick the user already made. This is the
+"one writer per file" guarantee from the engineering review (rec #1):
+the Mac owns its files; CI's data is merged in, not stamped over.
+
+Usage:  merge_curation_caches.py <artifact_dir>
+"""
+import json
+import os
+import sys
+
+# Cache filename -> (local path, artifact path basename)
+CACHES = [
+    "pull_quotes_combined.json",
+    "capsule_cache.json",
+]
+LOCAL_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "cache")
+
+
+def _load(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (FileNotFoundError, ValueError):
+        return {}
+
+
+def merge_one(name, art_dir):
+    art_path = os.path.join(art_dir, name)
+    local_path = os.path.join(LOCAL_DIR, name)
+    if not os.path.exists(art_path):
+        print(f"  {name}: no artifact file — skipped")
+        return 0
+    art = _load(art_path)
+    local = _load(local_path)
+    if not isinstance(art, dict) or not isinstance(local, dict):
+        print(f"  {name}: unexpected (non-dict) cache shape — skipped for safety")
+        return 0
+    added = 0
+    for key, val in art.items():
+        if key not in local:          # never overwrite local curation state
+            local[key] = val
+            added += 1
+    if added:
+        with open(local_path, "w") as f:
+            json.dump(local, f, indent=2, ensure_ascii=False)
+    print(f"  {name}: +{added} new entr{'y' if added == 1 else 'ies'} (existing preserved)")
+    return added
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: merge_curation_caches.py <artifact_dir>", file=sys.stderr)
+        return 2
+    art_dir = sys.argv[1]
+    total = sum(merge_one(name, art_dir) for name in CACHES)
+    print(f"Merged curation caches: {total} new entr{'y' if total == 1 else 'ies'} total")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why
On 2026-06-20 the local launchagent run started 00:25, the laptop drained to 1% battery and hibernated 03:15→10:31 (verified via `pmset -g log`), freezing the run ~7h so that day's trailers were missed. Root cause: a slow nightly capsule step on a battery-dependent machine.

Trailer **download** must stay local (YouTube blocks datacenter IPs + needs Safari cookies). Pull-quote scraping (Playwright+Gemini) and capsule pre-gen (Gemini) do **not** — both already run in CI's toolchain.

## What this does
- **CI (daily-check.yml):** two new **non-critical** steps (pull-quote scrape + capsule pre-gen) + a `curation-caches` artifact (7-day retention) + a guard that fails CI if `cache/approved_capsules.json` ever becomes tracked.
- **scripts/merge_curation_caches.py (new):** merges artifact → local **add-new-only**, so it never resets the user's `selected` picks or curated capsules.
- **local_daily.sh:** downloads + merges the artifact; **falls back** to local generation if the artifact is unavailable (safety net).
- **.gitignore:** documents that the caches + curated bank stay ignored.

## Engineering-review recommendations (all 5)
1. State separation — merge is add-new-only ✅
2. Non-critical CI steps (continue-on-error) ✅
3. No git bloat — artifact w/ retention-days:7, nothing committed ✅
4. Safety net — local fallback stays until CI is proven ✅
5. Hard guard against tracking the curated bank ✅

## Before merging — prove CI works (rec #4)
Trigger a manual run of the workflow, confirm pull-quote/capsule counts look normal and the `curation-caches` artifact appears. Until merged, main is untouched and the local run works exactly as before (additive change, no conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)